### PR TITLE
feat(node-env): enhanced configuration for granular control

### DIFF
--- a/projects/flosportsinc/ng-env-transfer-state/README.md
+++ b/projects/flosportsinc/ng-env-transfer-state/README.md
@@ -6,6 +6,20 @@ Transfer server side environment variables to use as configuration values throug
 npm i @flosportsinc/ng-env-transfer-state
 ```
 
+Inside your `AppModule` install `NodeEnvTransferModule` like so:
+
+```js
+import { NgModule } from '@angular/core'
+import { NodeEnvTransferModule } from '@flosportsinc/ng-env-transfer-state'
+
+@NgModule({
+  imports: [
+    NodeEnvTransferModule
+  ]
+})
+export class AppModule { }
+```
+
 Inside your `BrowserModule` install `NodeEnvTransferBrowserModule` like so:
 
 ```js
@@ -14,7 +28,14 @@ import { NodeEnvTransferBrowserModule } from '@flosportsinc/ng-env-transfer-stat
 
 @NgModule({
   imports: [
-    NodeEnvTransferBrowserModule
+    NodeEnvTransferBrowserModule, // default behavior simply return the values passed from Node or an empty object if none are found.
+    NodeEnvTransferBrowserModule.config({ // you can also merge custom values with server values
+      mergeWithServer: {
+        MyEnvValue1: true,
+        MyEnvValue2: 'string',
+        MyEnvValue3: undefined
+      }
+    })
   ]
 })
 export class AppBrowserModule { }
@@ -39,3 +60,59 @@ export class AppServerModule { }
 ```
 
 The collection of strings provided inside the `withSelectedKeys` static method will be plucked from `process.env` and transferred to the client. By default none are provided. Please be aware of the security risks involved when selecting environment variables. Do not expose sensitive information.
+
+
+### Simple Usage
+```js
+import { Component, Inject } from '@angular/core'
+import { ENV } from '@flosportsinc/ng-env-transfer-state'
+
+@Component({
+  selector: 'app-home',
+  templateUrl: './home.component.html',
+  styleUrls: ['./home.component.scss']
+})
+export class HomeComponent {
+  constructor(@Inject(ENV) env: any) {
+    console.log(env)
+  }
+}
+```
+
+### Service Usage
+```js
+import { Component } from '@angular/core'
+import { NodeEnvTransferService } from '@flosportsinc/ng-env-transfer-state'
+
+@Component({
+  selector: 'app-home',
+  templateUrl: './home.component.html',
+  styleUrls: ['./home.component.scss']
+})
+export class HomeComponent {
+  constructor(nts: NodeEnvTransferService) {
+    console.log(nts.env)
+  }
+}
+```
+
+### Service Usage w/ Generic
+```js
+import { Component } from '@angular/core'
+import { NodeEnvTransferService } from '@flosportsinc/ng-env-transfer-state'
+
+interface MyTypedEnv {
+  readonly coolValue?: string
+}
+
+@Component({
+  selector: 'app-home',
+  templateUrl: './home.component.html',
+  styleUrls: ['./home.component.scss']
+})
+export class HomeComponent {
+  constructor(nts: NodeEnvTransferService<MyTypedEnv>) {
+    console.log(nts.env.coolValue)
+  }
+}
+```

--- a/projects/flosportsinc/ng-env-transfer-state/browser/node-env-transfer.browser.module.spec.ts
+++ b/projects/flosportsinc/ng-env-transfer-state/browser/node-env-transfer.browser.module.spec.ts
@@ -1,6 +1,6 @@
 import { NodeEnvTransferBrowserModule } from './node-env-transfer.browser.module'
 import { TestBed } from '@angular/core/testing'
-import { ENV_CONFIG, ENV_CONFIG_TS_KEY } from './node-env-transfer.tokens'
+import { ENV, ENV_CONFIG_TS_KEY } from './node-env-transfer.tokens'
 import { TransferState } from '@angular/platform-browser'
 
 describe(NodeEnvTransferBrowserModule.name, () => {
@@ -17,7 +17,7 @@ describe(NodeEnvTransferBrowserModule.name, () => {
     const stateKey = TestBed.get(ENV_CONFIG_TS_KEY)
     const spyTs = spyOn(ts, 'get').and.callThrough()
 
-    expect(TestBed.get(ENV_CONFIG)).toBeTruthy()
+    expect(TestBed.get(ENV)).toBeTruthy()
     expect(stateKey).toEqual('NODE_ENV')
     expect(spyTs).toHaveBeenCalledWith('NODE_ENV', {})
   })

--- a/projects/flosportsinc/ng-env-transfer-state/browser/node-env-transfer.browser.module.spec.ts
+++ b/projects/flosportsinc/ng-env-transfer-state/browser/node-env-transfer.browser.module.spec.ts
@@ -1,24 +1,45 @@
-import { NodeEnvTransferBrowserModule } from './node-env-transfer.browser.module'
+import { NodeEnvTransferBrowserModule, INodeEnvTransferBrowserModuleConfig } from './node-env-transfer.browser.module'
 import { TestBed } from '@angular/core/testing'
 import { ENV, ENV_CONFIG_TS_KEY } from './node-env-transfer.tokens'
 import { TransferState } from '@angular/platform-browser'
 
+const setupTestBed = (config?: INodeEnvTransferBrowserModuleConfig) => {
+  TestBed.configureTestingModule({
+    imports: [
+      NodeEnvTransferBrowserModule.config(config)
+    ]
+  })
+}
+
 describe(NodeEnvTransferBrowserModule.name, () => {
   afterEach(() => TestBed.resetTestingModule())
 
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [NodeEnvTransferBrowserModule]
-    })
-  })
-
   it('should construct with correct default values', () => {
+    setupTestBed()
     const ts = TestBed.get(TransferState) as TransferState
     const stateKey = TestBed.get(ENV_CONFIG_TS_KEY)
     const spyTs = spyOn(ts, 'get').and.callThrough()
 
-    expect(TestBed.get(ENV)).toBeTruthy()
+    expect(TestBed.get(ENV)).toEqual({})
     expect(stateKey).toEqual('NODE_ENV')
     expect(spyTs).toHaveBeenCalledWith('NODE_ENV', {})
+  })
+
+  it('should ...', () => {
+    setupTestBed({ mergeWithServer: { test: '1' } })
+
+    expect(TestBed.get(ENV)).toEqual({ test: '1' })
+  })
+
+  it('should merge server transferred values', () => {
+    setupTestBed({ mergeWithServer: { test: '1' } })
+
+    const ts = TestBed.get(TransferState) as TransferState
+    spyOn(ts, 'get').and.returnValue({ FROM_SERVER: true })
+
+    expect(TestBed.get(ENV)).toEqual({
+      FROM_SERVER: true,
+      test: '1'
+    })
   })
 })

--- a/projects/flosportsinc/ng-env-transfer-state/browser/node-env-transfer.browser.module.ts
+++ b/projects/flosportsinc/ng-env-transfer-state/browser/node-env-transfer.browser.module.ts
@@ -4,7 +4,7 @@ import { NodeEnvTransferModule } from './node-env-transfer.common.module'
 import { BrowserTransferStateModule } from '@angular/platform-browser'
 import { ENV, ENV_CONFIG_TS_KEY, ENV_CONFIG_DEFAULT } from './node-env-transfer.tokens'
 
-export function defaultBrowserFactory(ts: TransferState, stateKey: string, merge = {}) {
+export function defaultBrowserFactory(ts: TransferState, stateKey: string, merge: Object) {
   return {
     ...ts.get(makeStateKey(stateKey), {}),
     ...merge
@@ -19,6 +19,8 @@ export interface INodeEnvTransferBrowserModuleConfig {
   readonly mergeWithServer?: INodeEnvTransferBrowserModuleConfigDict
 }
 
+export const NODE_ENV_CONFIG_DEFAULT = {}
+
 @NgModule({
   imports: [
     BrowserTransferStateModule,
@@ -27,7 +29,7 @@ export interface INodeEnvTransferBrowserModuleConfig {
   providers: [
     {
       provide: ENV_CONFIG_DEFAULT,
-      useValue: {}
+      useValue: NODE_ENV_CONFIG_DEFAULT
     },
     {
       provide: ENV,
@@ -43,7 +45,7 @@ export class NodeEnvTransferBrowserModule {
       providers: [
         {
           provide: ENV_CONFIG_DEFAULT,
-          useValue: config.mergeWithServer || {}
+          useValue: config.mergeWithServer || NODE_ENV_CONFIG_DEFAULT
         }
       ]
     }

--- a/projects/flosportsinc/ng-env-transfer-state/browser/node-env-transfer.browser.module.ts
+++ b/projects/flosportsinc/ng-env-transfer-state/browser/node-env-transfer.browser.module.ts
@@ -1,24 +1,51 @@
-import { NgModule } from '@angular/core'
+import { NgModule, ModuleWithProviders } from '@angular/core'
 import { TransferState, makeStateKey } from '@angular/platform-browser'
-import { ENV_CONFIG, ENV_CONFIG_TS_KEY } from './node-env-transfer.tokens'
-import { NodeEnvTransferCommonModule } from './node-env-transfer.common.module'
+import { NodeEnvTransferModule } from './node-env-transfer.common.module'
 import { BrowserTransferStateModule } from '@angular/platform-browser'
+import { ENV, ENV_CONFIG_TS_KEY, ENV_CONFIG_DEFAULT } from './node-env-transfer.tokens'
 
-export function defaultBrowserFactory(ts: TransferState, stateKey: string) {
-  return ts.get(makeStateKey(stateKey), {})
+export function defaultBrowserFactory(ts: TransferState, stateKey: string, merge = {}) {
+  return {
+    ...ts.get(makeStateKey(stateKey), {}),
+    ...merge
+  }
+}
+
+export interface INodeEnvTransferBrowserModuleConfigDict {
+  readonly [key: string]: string | boolean | undefined
+}
+
+export interface INodeEnvTransferBrowserModuleConfig {
+  readonly mergeWithServer?: INodeEnvTransferBrowserModuleConfigDict
 }
 
 @NgModule({
   imports: [
     BrowserTransferStateModule,
-    NodeEnvTransferCommonModule
+    NodeEnvTransferModule
   ],
   providers: [
     {
-      provide: ENV_CONFIG,
+      provide: ENV_CONFIG_DEFAULT,
+      useValue: {}
+    },
+    {
+      provide: ENV,
       useFactory: defaultBrowserFactory,
-      deps: [TransferState, ENV_CONFIG_TS_KEY]
+      deps: [TransferState, ENV_CONFIG_TS_KEY, ENV_CONFIG_DEFAULT]
     }
   ]
 })
-export class NodeEnvTransferBrowserModule { }
+export class NodeEnvTransferBrowserModule {
+  static config(config: INodeEnvTransferBrowserModuleConfig = {}): ModuleWithProviders {
+    return {
+      ngModule: NodeEnvTransferBrowserModule,
+      providers: [
+        {
+          provide: ENV_CONFIG_DEFAULT,
+          useValue: config.mergeWithServer || {}
+        }
+      ]
+    }
+  }
+}

--- a/projects/flosportsinc/ng-env-transfer-state/common/node-env-transfer.common.module.spec.ts
+++ b/projects/flosportsinc/ng-env-transfer-state/common/node-env-transfer.common.module.spec.ts
@@ -1,13 +1,13 @@
 import { TestBed } from '@angular/core/testing'
 import { ENV_CONFIG_TS_KEY } from './node-env-transfer.tokens'
-import { NodeEnvTransferCommonModule } from './node-env-transfer.common.module'
+import { NodeEnvTransferModule } from './node-env-transfer.common.module'
 
-describe(NodeEnvTransferCommonModule.name, () => {
+describe(NodeEnvTransferModule.name, () => {
   afterEach(() => TestBed.resetTestingModule())
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [NodeEnvTransferCommonModule]
+      imports: [NodeEnvTransferModule]
     })
   })
 

--- a/projects/flosportsinc/ng-env-transfer-state/common/node-env-transfer.common.module.ts
+++ b/projects/flosportsinc/ng-env-transfer-state/common/node-env-transfer.common.module.ts
@@ -11,4 +11,4 @@ import { NodeEnvTransferService } from './node-env-transfer.service'
     }
   ]
 })
-export class NodeEnvTransferCommonModule { }
+export class NodeEnvTransferModule { }

--- a/projects/flosportsinc/ng-env-transfer-state/common/node-env-transfer.service.spec.ts
+++ b/projects/flosportsinc/ng-env-transfer-state/common/node-env-transfer.service.spec.ts
@@ -1,7 +1,7 @@
 import { TestBed } from '@angular/core/testing'
 import { NodeEnvTransferService } from './node-env-transfer.service'
-import { NodeEnvTransferCommonModule } from './node-env-transfer.common.module'
-import { ENV_CONFIG } from './node-env-transfer.tokens'
+import { NodeEnvTransferModule } from './node-env-transfer.common.module'
+import { ENV } from './node-env-transfer.tokens'
 
 interface OurConfig {
   readonly someProperty: number
@@ -12,10 +12,10 @@ describe(NodeEnvTransferService.name, () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [NodeEnvTransferCommonModule],
+      imports: [NodeEnvTransferModule],
       providers: [
         {
-          provide: ENV_CONFIG,
+          provide: ENV,
           useValue: {
             someProperty: 123
           }

--- a/projects/flosportsinc/ng-env-transfer-state/common/node-env-transfer.service.ts
+++ b/projects/flosportsinc/ng-env-transfer-state/common/node-env-transfer.service.ts
@@ -1,12 +1,12 @@
 import { Inject, Injectable } from '@angular/core'
-import { ENV_CONFIG } from './node-env-transfer.tokens'
+import { ENV } from './node-env-transfer.tokens'
 
 export interface INodeEnvTransferService<T> {
   readonly env: T
 }
 
 @Injectable()
-export class NodeEnvTransferService<T> implements INodeEnvTransferService<T> {
-  constructor(@Inject(ENV_CONFIG) private _env: any) { }
+export class NodeEnvTransferService<T = any> implements INodeEnvTransferService<T> {
+  constructor(@Inject(ENV) private _env: any) { }
   public readonly env: T = this._env
 }

--- a/projects/flosportsinc/ng-env-transfer-state/common/node-env-transfer.tokens.ts
+++ b/projects/flosportsinc/ng-env-transfer-state/common/node-env-transfer.tokens.ts
@@ -1,6 +1,5 @@
-import { InjectionToken } from '@angular/core'
-
-export const ENV_CONFIG = new InjectionToken('flo.node-env-transfer.config')
-export const ENV_CONFIG_TS_KEY = new InjectionToken('flo.node-env-transfer.config-ts-key')
-export const ENV_CONFIG_FILTER_KEYS = new InjectionToken('flo.node-env-transfer.config-filter-keys')
-export const NODE_ENV = new InjectionToken('flo.node-env-transfer.node-env')
+export const ENV = 'flo.node-env-transfer.config'
+export const ENV_CONFIG_DEFAULT = 'flo.node-env-transfer.config-browser-default'
+export const ENV_CONFIG_TS_KEY = 'flo.node-env-transfer.config-ts-key'
+export const ENV_CONFIG_FILTER_KEYS = 'flo.node-env-transfer.config-filter-keys'
+export const NODE_ENV = 'flo.node-env-transfer.node-env'

--- a/projects/flosportsinc/ng-env-transfer-state/common/node-env-transfer.tokens.ts
+++ b/projects/flosportsinc/ng-env-transfer-state/common/node-env-transfer.tokens.ts
@@ -1,5 +1,5 @@
 export const ENV = 'flo.node-env-transfer.config'
 export const ENV_CONFIG_DEFAULT = 'flo.node-env-transfer.config-browser-default'
 export const ENV_CONFIG_TS_KEY = 'flo.node-env-transfer.config-ts-key'
-export const ENV_CONFIG_FILTER_KEYS = 'flo.node-env-transfer.config-filter-keys'
+export const ENV_CONFIG_SERVER = 'flo.node-env-transfer.config-server'
 export const NODE_ENV = 'flo.node-env-transfer.node-env'

--- a/projects/flosportsinc/ng-env-transfer-state/server/node-env-transfer.server.module.spec.ts
+++ b/projects/flosportsinc/ng-env-transfer-state/server/node-env-transfer.server.module.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed } from '@angular/core/testing'
-import { ENV_CONFIG_FILTER_KEYS, NODE_ENV, ENV_CONFIG } from './node-env-transfer.tokens'
+import { ENV_CONFIG_FILTER_KEYS, NODE_ENV, ENV } from './node-env-transfer.tokens'
 import { NodeEnvTransferServerModule, serverEnvConfigFactory, nodeEnvFactory } from './node-env-transfer.server.module'
 import { APP_BOOTSTRAP_LISTENER } from '@angular/core'
 import { TransferState } from '@angular/platform-browser'
@@ -38,7 +38,7 @@ describe(NodeEnvTransferServerModule.name, () => {
   it('should pluck keys', () => {
     setupTestBed()(['cool_key'])
     const toPluck = TestBed.get(ENV_CONFIG_FILTER_KEYS)
-    const env = TestBed.get(ENV_CONFIG)
+    const env = TestBed.get(ENV)
 
     expect(toPluck.length).toEqual(1)
     expect(toPluck).toContain('cool_key')

--- a/projects/flosportsinc/ng-env-transfer-state/server/node-env-transfer.server.module.spec.ts
+++ b/projects/flosportsinc/ng-env-transfer-state/server/node-env-transfer.server.module.spec.ts
@@ -1,19 +1,19 @@
 import { TestBed } from '@angular/core/testing'
-import { ENV_CONFIG_FILTER_KEYS, NODE_ENV, ENV } from './node-env-transfer.tokens'
-import { NodeEnvTransferServerModule, serverEnvConfigFactory, nodeEnvFactory } from './node-env-transfer.server.module'
+import { NODE_ENV, ENV, ENV_CONFIG_SERVER } from './node-env-transfer.tokens'
 import { APP_BOOTSTRAP_LISTENER } from '@angular/core'
 import { TransferState } from '@angular/platform-browser'
+import { NodeEnvTransferServerModule, INodeEnvTransferServerModuleConfig, nodeEnvFactory } from './node-env-transfer.server.module'
+
+const defNode = { cool_key: 'cool value!' }
 
 const setupTestBed =
-  (nodeProcess = { cool_key: 'cool value!' }) =>
-    (pluckKeys?: ReadonlyArray<string>) => {
-      const mod = pluckKeys
-        ? pluckKeys.length
-          ? NodeEnvTransferServerModule.withSelectedKeys(pluckKeys)
-          : NodeEnvTransferServerModule.withSelectedKeys()
+  (nodeProcess?: Object) =>
+    (config?: Partial<INodeEnvTransferServerModuleConfig>) => {
+      const ServerModule = config
+        ? NodeEnvTransferServerModule.config(config)
         : NodeEnvTransferServerModule
       TestBed.configureTestingModule({
-        imports: [mod],
+        imports: [ServerModule],
         providers: [{
           provide: NODE_ENV,
           useValue: nodeProcess
@@ -26,18 +26,18 @@ describe(NodeEnvTransferServerModule.name, () => {
   afterEach(() => TestBed.resetTestingModule())
 
   it('should pluck none by default A', () => {
-    setupTestBed()([])
-    expect(TestBed.get(ENV_CONFIG_FILTER_KEYS).length).toEqual(0)
+    setupTestBed(defNode)({})
+    expect(TestBed.get(ENV_CONFIG_SERVER).selectKeys.length).toEqual(0)
   })
 
   it('should pluck nonde by default B', () => {
-    setupTestBed()()
-    expect(TestBed.get(ENV_CONFIG_FILTER_KEYS).length).toEqual(0)
+    setupTestBed(defNode)()
+    expect(TestBed.get(ENV_CONFIG_SERVER).selectKeys.length).toEqual(0)
   })
 
   it('should pluck keys', () => {
-    setupTestBed()(['cool_key'])
-    const toPluck = TestBed.get(ENV_CONFIG_FILTER_KEYS)
+    setupTestBed(defNode)({ selectKeys: ['cool_key'] })
+    const toPluck = TestBed.get(ENV_CONFIG_SERVER).selectKeys
     const env = TestBed.get(ENV)
 
     expect(toPluck.length).toEqual(1)
@@ -46,7 +46,7 @@ describe(NodeEnvTransferServerModule.name, () => {
   })
 
   it('should bootstrap and set transfer state', () => {
-    setupTestBed()(['cool_key'])
+    setupTestBed(defNode)({ selectKeys: ['cool_key'] })
 
     const factory = TestBed.get(APP_BOOTSTRAP_LISTENER)[0]
     const ts = TestBed.get(TransferState) as TransferState
@@ -58,8 +58,62 @@ describe(NodeEnvTransferServerModule.name, () => {
   })
 
   it('handle default filter case', () => {
-    expect(serverEnvConfigFactory(undefined, [])).toEqual({})
+    setupTestBed()()
+    expect(TestBed.get(ENV_CONFIG_SERVER)).toBeTruthy()
+  })
 
-    expect(nodeEnvFactory()).toEqual(process.env)
+  it('handle default filter case', () => {
+    expect(nodeEnvFactory()).toEqual({})
+  })
+
+  it('should selecte by pattern', () => {
+    setupTestBed({
+      NODE_ENV_VAR: 'SOMETHING',
+      FLO_SERVER_API: 'https://url.ref',
+      FLO_SERVER_API2: 'https://url.ref2'
+    })({
+      extractor: new RegExp('FLO_')
+    })
+
+    const env = TestBed.get(ENV)
+
+    expect(Object.keys(env).length).toEqual(2)
+    expect(env.FLO_SERVER_API).toEqual('https://url.ref')
+    expect(env.FLO_SERVER_API2).toEqual('https://url.ref2')
+  })
+
+  it('should selecte by pattern and rename key', () => {
+    setupTestBed({
+      NODE_ENV_VAR: 'SOMETHING',
+      FLO_SERVER_API: 'https://url.ref',
+      FLO_SERVER_API2: 'https://url.ref2'
+    })({
+      extractor: new RegExp('FLO_'),
+      keyReplacer: key => key.replace('FLO_', '')
+    })
+
+    const env = TestBed.get(ENV)
+
+    expect(Object.keys(env).length).toEqual(2)
+    expect(env.SERVER_API).toEqual('https://url.ref')
+    expect(env.SERVER_API2).toEqual('https://url.ref2')
+  })
+
+
+  it('should handle combination of selectedKeys + extractor pattern', () => {
+    const testEnv = { NODE_ENV_VAR: 'SOMETHING', FLO_SERVER_API: 'https://url.ref' }
+    setupTestBed(testEnv)({
+      selectKeys: ['NODE_ENV_VAR'],
+      extractor: new RegExp('FLO_')
+    })
+
+    const env = TestBed.get(ENV)
+    expect(env).toEqual(testEnv)
+  })
+
+  it('should have default regex pattern matcher of undefined', () => {
+    setupTestBed()()
+
+    expect(TestBed.get(ENV_CONFIG_SERVER).extractor).toBeUndefined()
   })
 })

--- a/projects/flosportsinc/ng-env-transfer-state/server/node-env-transfer.server.module.ts
+++ b/projects/flosportsinc/ng-env-transfer-state/server/node-env-transfer.server.module.ts
@@ -1,8 +1,8 @@
 import { NgModule, APP_BOOTSTRAP_LISTENER, ApplicationRef, ModuleWithProviders } from '@angular/core'
 import { ServerTransferStateModule } from '@angular/platform-server'
 import { TransferState, makeStateKey } from '@angular/platform-browser'
-import { NodeEnvTransferCommonModule } from './node-env-transfer.common.module'
-import { NODE_ENV, ENV_CONFIG_FILTER_KEYS, ENV_CONFIG, ENV_CONFIG_TS_KEY } from './node-env-transfer.tokens'
+import { NodeEnvTransferModule } from './node-env-transfer.common.module'
+import { NODE_ENV, ENV_CONFIG_FILTER_KEYS, ENV, ENV_CONFIG_TS_KEY } from './node-env-transfer.tokens'
 import { filter, first, take } from 'rxjs/operators'
 
 export function serverEnvConfigFactory(nodeEnv = {}, filterKeys: ReadonlyArray<string>) {
@@ -27,7 +27,7 @@ export function nodeEnvFactory() {
 @NgModule({
   imports: [
     ServerTransferStateModule,
-    NodeEnvTransferCommonModule
+    NodeEnvTransferModule
   ],
   providers: [
     {
@@ -39,14 +39,14 @@ export function nodeEnvFactory() {
       useFactory: nodeEnvFactory
     },
     {
-      provide: ENV_CONFIG,
+      provide: ENV,
       useFactory: serverEnvConfigFactory,
       deps: [NODE_ENV, ENV_CONFIG_FILTER_KEYS]
     },
     {
       provide: APP_BOOTSTRAP_LISTENER,
       useFactory: onBootstrap,
-      deps: [ApplicationRef, TransferState, ENV_CONFIG, ENV_CONFIG_TS_KEY],
+      deps: [ApplicationRef, TransferState, ENV, ENV_CONFIG_TS_KEY],
       multi: true
     }
   ]

--- a/src/app/app.browser.module.ts
+++ b/src/app/app.browser.module.ts
@@ -12,11 +12,15 @@ import { SvgTransferStateBrowserModule } from '@flosportsinc/ng-svg-transfer-sta
 @NgModule({
   imports: [
     AdBlockBrowserModule.usingUrl('/assets/ads.js'),
-    NodeEnvTransferBrowserModule,
     CookieBrowserModule,
     HlsModule,
     DashModule,
     AppModule,
+    NodeEnvTransferBrowserModule.config({
+      mergeWithServer: {
+        test: 'ok'
+      }
+    }),
     SvgTransferStateBrowserModule
   ],
   providers: [

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -21,9 +21,11 @@ import { MseModule } from '@flosportsinc/ng-media-source-extensions'
 import { WindowModule } from '@flosportsinc/ng-window'
 import { SvgTransferStateModule } from '@flosportsinc/ng-svg-transfer-state'
 import { IconsComponent } from './icons/icons.component'
+import { NodeEnvTransferModule, NodeEnvTransferService } from '@flosportsinc/ng-env-transfer-state'
 
 @NgModule({
   imports: [
+    NodeEnvTransferModule,
     WindowModule,
     MseModule,
     FormsModule,
@@ -50,4 +52,8 @@ import { IconsComponent } from './icons/icons.component'
     NotFoundComponent
   ]
 })
-export class AppModule { }
+export class AppModule {
+  constructor(env: NodeEnvTransferService) {
+    console.log(env.env)
+  }
+}

--- a/src/app/app.server.module.ts
+++ b/src/app/app.server.module.ts
@@ -17,7 +17,6 @@ import { SvgTransferStateServerModule } from '@flosportsinc/ng-svg-transfer-stat
     ModuleMapLoaderModule,
     ServerTransferStateModule,
     AdBlockServerModule,
-    NodeEnvTransferServerModule,
     AppModule,
     WindowServerModule,
     CookieServerModule,

--- a/src/app/app.server.module.ts
+++ b/src/app/app.server.module.ts
@@ -20,6 +20,7 @@ import { SvgTransferStateServerModule } from '@flosportsinc/ng-svg-transfer-stat
     AppModule,
     WindowServerModule,
     CookieServerModule,
+    NodeEnvTransferServerModule,
     SvgTransferStateServerModule.withSvgAssetRoot('dist/flo-angular/browser/assets/svg')
   ],
   providers: [

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core'
+import { Component, ChangeDetectionStrategy, Inject } from '@angular/core'
 
 @Component({
   selector: 'app-home',
@@ -6,6 +6,4 @@ import { Component, ChangeDetectionStrategy } from '@angular/core'
   styleUrls: ['./home.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class HomeComponent {
-
-}
+export class HomeComponent { }


### PR DESCRIPTION
BREAKING CHANGES: NodeEnvTransferCommonModule renamed to NodeEnvTransferModule. NodeEnvTransferBrowserModule uses a different init signature. NodeEnvTransferServerModule uses a different init signature.