### PR TITLE
fix(mse): module config works with AOT compiler

### DIFF
--- a/projects/flosportsinc/ng-media-source-extensions/core/mse.directive.spec.ts
+++ b/projects/flosportsinc/ng-media-source-extensions/core/mse.directive.spec.ts
@@ -8,9 +8,10 @@ import {
 } from './mse.tokens'
 import { FloMseModule } from './mse.module'
 import {
-  FloHlsModule, DEFAULT_MODULE_CONFIG, MEDIA_SOURCE_EXTENSION_HLS_INIT_CONFIG, defaultHlsSupportedNativelyFunction,
+  FloHlsModule, MEDIA_SOURCE_EXTENSION_HLS_CONFIG, defaultHlsSupportedNativelyFunction,
   defaultIsSupportedFactory, defaultMseClientInitFunction, defaultMseClientDestroyFunction,
-  defaultHlsPatternCheck
+  defaultHlsPatternCheck,
+  DEFAULT_MODULE_HLS_CONFIG
 } from '../hls/hls.module'
 import { FloDashModule } from '../dash/dash.module'
 import * as Hls from 'hls.js'
@@ -53,8 +54,8 @@ export class HlsTestComponent {
   exports: [HlsTestComponent],
   providers: [
     {
-      provide: MEDIA_SOURCE_EXTENSION_HLS_INIT_CONFIG,
-      useValue: DEFAULT_MODULE_CONFIG
+      provide: MEDIA_SOURCE_EXTENSION_HLS_CONFIG,
+      useValue: DEFAULT_MODULE_HLS_CONFIG
     },
     {
       provide: SUPPORTS_MSE_TARGET_NATIVELY,
@@ -69,7 +70,7 @@ export class HlsTestComponent {
     {
       provide: MEDIA_SOURCE_EXTENSION_LIBRARY_INIT_TASK,
       useFactory: defaultMseClientInitFunction,
-      deps: [MEDIA_SOURCE_EXTENSION_HLS_INIT_CONFIG],
+      deps: [MEDIA_SOURCE_EXTENSION_HLS_CONFIG],
       multi: true
     },
     {

--- a/projects/flosportsinc/ng-media-source-extensions/hls/hls.module.spec.ts
+++ b/projects/flosportsinc/ng-media-source-extensions/hls/hls.module.spec.ts
@@ -1,7 +1,8 @@
 import {
   FloHlsModule, defaultHlsSupportedNativelyFunction, defaultIsSupportedFactory,
-  MEDIA_SOURCE_EXTENSION_HLS_INIT_CONFIG,
-  DEFAULT_MODULE_CONFIG,
+  MEDIA_SOURCE_EXTENSION_HLS_CONFIG,
+  MEDIA_SOURCE_EXTENSION_SELF_HEAL,
+  DEFAULT_MODULE_HLS_CONFIG,
   selfHealSwitch
 } from './hls.module'
 import { TestBed, async } from '@angular/core/testing'
@@ -148,10 +149,10 @@ describe(FloHlsModule.name, () => {
 
   describe('when using module config', () => {
     it('should handle empty config object', done => {
-      TestBed.configureTestingModule({ imports: [FloHlsModule.config()], declarations: [HlsTestComponent] })
+      TestBed.configureTestingModule({ imports: [FloHlsModule.config({})], declarations: [HlsTestComponent] })
 
-      const sut = TestBed.get(MEDIA_SOURCE_EXTENSION_HLS_INIT_CONFIG)
-      expect(sut).toEqual(DEFAULT_MODULE_CONFIG)
+      const sut = TestBed.get(MEDIA_SOURCE_EXTENSION_HLS_CONFIG)
+      expect(sut).toEqual(DEFAULT_MODULE_HLS_CONFIG)
       done()
     })
 
@@ -161,8 +162,8 @@ describe(FloHlsModule.name, () => {
         declarations: [HlsTestComponent]
       })
 
-      const sut = TestBed.get(MEDIA_SOURCE_EXTENSION_HLS_INIT_CONFIG)
-      expect(sut).toEqual(DEFAULT_MODULE_CONFIG)
+      const sut = TestBed.get(MEDIA_SOURCE_EXTENSION_HLS_CONFIG)
+      expect(sut).toEqual(DEFAULT_MODULE_HLS_CONFIG)
       done()
     })
   })

--- a/projects/flosportsinc/ng-media-source-extensions/hls/hls.module.ts
+++ b/projects/flosportsinc/ng-media-source-extensions/hls/hls.module.ts
@@ -17,27 +17,25 @@ import { NgModule, ModuleWithProviders, InjectionToken } from '@angular/core'
 import * as Hls from 'hls.js'
 
 const exectionKey = 'HLS'
-export const MEDIA_SOURCE_EXTENSION_HLS_INIT_CONFIG = new InjectionToken('fs.mse.lib.hls.init.cfg')
+export const MEDIA_SOURCE_EXTENSION_HLS_MODULE_CONFIG = new InjectionToken('fs.mse.lib.hls.init.cfg.mdl')
+export const MEDIA_SOURCE_EXTENSION_HLS_CONFIG = new InjectionToken('fs.mse.lib.hls.init.cfg')
+export const MEDIA_SOURCE_EXTENSION_SELF_HEAL = new InjectionToken('fs.mse.lib.cfg.selfHeal')
+export const DEFAULT_MEDIA_SOURCE_EXTENSION_SELF_HEAL = true
 
 export interface HlsMessage {
   readonly key: keyof typeof Hls.Events
   readonly message: any
 }
 
-export interface IFloHlsModuleConfig {
-  readonly selfHeal: boolean
-}
+export type IHlsConfig = Hls.Config
 
 export interface IHlsModuleConfig {
-  readonly floConfig: Partial<IFloHlsModuleConfig>
-  readonly hlsConfig: Partial<Hls.Config>
+  readonly selfHeal: boolean
+  readonly hlsConfig: Partial<IHlsConfig>
 }
 
-export const DEFAULT_MODULE_CONFIG: IHlsModuleConfig = {
-  floConfig: {
-    selfHeal: true
-  },
-  hlsConfig: {}
+export const DEFAULT_MODULE_HLS_CONFIG: Partial<IHlsConfig> = {
+  capLevelToPlayerSize: true
 }
 
 export function defaultIsSupportedFactory() {
@@ -89,15 +87,15 @@ export const selfHealFunc = (client: Hls) => {
 
 // TODO: if another Media Error is raised 'quickly' after this first Media Error,
 // TODO: first call hls.swapAudioCodec(), then call hls.recoverMediaError().
-export function defaultMseClientInitFunction(config: IHlsModuleConfig): IMseInit<Hls, HlsMessage> {
+export function defaultMseClientInitFunction(selfHeal: boolean, hlsConfig: Hls.Config): IMseInit<Hls, HlsMessage> {
   const func: IMseInitFunc<Hls, HlsMessage> = initEvent => {
-    const client = new Hls(config.hlsConfig)
+    const client = new Hls(hlsConfig)
     Object.keys(Hls.Events).forEach(k => {
       client.on(Hls.Events[k], (key: any, message) => initEvent.messageSource.next({ key, message }))
     })
 
     // setup fatal error recovery if selfHeal = true
-    config.floConfig.selfHeal && selfHealFunc(client)
+    selfHeal && selfHealFunc(client)
 
     client.loadSource(initEvent.src)
     client.attachMedia(initEvent.videoElement)
@@ -129,13 +127,24 @@ export function defaultHlsPatternCheck(): IMsePatternCheck {
   }
 }
 
+export function mergeModuleSettings(hlsConfig: Partial<IHlsConfig>) {
+  return {
+    ...DEFAULT_MODULE_HLS_CONFIG,
+    ...hlsConfig
+  }
+}
+
 @NgModule({
   imports: [FloMseModule],
   exports: [FloMseModule],
   providers: [
     {
-      provide: MEDIA_SOURCE_EXTENSION_HLS_INIT_CONFIG,
-      useValue: DEFAULT_MODULE_CONFIG
+      provide: MEDIA_SOURCE_EXTENSION_HLS_CONFIG,
+      useValue: DEFAULT_MODULE_HLS_CONFIG
+    },
+    {
+      provide: MEDIA_SOURCE_EXTENSION_SELF_HEAL,
+      useValue: DEFAULT_MEDIA_SOURCE_EXTENSION_SELF_HEAL
     },
     {
       provide: SUPPORTS_MSE_TARGET_NATIVELY,
@@ -150,7 +159,7 @@ export function defaultHlsPatternCheck(): IMsePatternCheck {
     {
       provide: MEDIA_SOURCE_EXTENSION_LIBRARY_INIT_TASK,
       useFactory: defaultMseClientInitFunction,
-      deps: [MEDIA_SOURCE_EXTENSION_HLS_INIT_CONFIG],
+      deps: [MEDIA_SOURCE_EXTENSION_SELF_HEAL, MEDIA_SOURCE_EXTENSION_HLS_CONFIG],
       multi: true
     },
     {
@@ -166,22 +175,19 @@ export function defaultHlsPatternCheck(): IMsePatternCheck {
   ]
 })
 export class FloHlsModule {
-  static config(config: Partial<IHlsModuleConfig> = DEFAULT_MODULE_CONFIG): ModuleWithProviders {
+  static config(config: Partial<IHlsModuleConfig>): ModuleWithProviders {
     return {
       ngModule: FloHlsModule,
       providers: [
+        { provide: MEDIA_SOURCE_EXTENSION_HLS_MODULE_CONFIG, useValue: config.hlsConfig },
         {
-          provide: MEDIA_SOURCE_EXTENSION_HLS_INIT_CONFIG,
-          useValue: {
-            floConfig: {
-              ...DEFAULT_MODULE_CONFIG.floConfig,
-              ...config.floConfig
-            },
-            hlsConfig: {
-              ...DEFAULT_MODULE_CONFIG.hlsConfig,
-              ...config.hlsConfig
-            }
-          }
+          provide: MEDIA_SOURCE_EXTENSION_SELF_HEAL,
+          useValue: config.selfHeal === undefined ? DEFAULT_MEDIA_SOURCE_EXTENSION_SELF_HEAL : config.selfHeal
+        },
+        {
+          provide: MEDIA_SOURCE_EXTENSION_HLS_CONFIG,
+          deps: [MEDIA_SOURCE_EXTENSION_HLS_MODULE_CONFIG],
+          useFactory: mergeModuleSettings
         }
       ]
     }

--- a/src/app/app.browser.module.ts
+++ b/src/app/app.browser.module.ts
@@ -16,11 +16,7 @@ import { SvgTransferStateBrowserModule } from '@flosportsinc/ng-svg-transfer-sta
     CookieBrowserModule,
     AppModule,
     FloDashModule,
-    FloHlsModule.config({
-      hlsConfig: {
-        liveSyncDurationCount: 6
-      }
-    }),
+    FloHlsModule,
     FloNodeEnvTransferBrowserModule.config({
       mergeWithServer: {
         browserOnly: 'testing-123'


### PR DESCRIPTION
BREAKING CHANGE: module configuration API has changed to better work with the AOT compiler. Module now defaults with the setting capLevelToPlayerSize set to true.